### PR TITLE
Update com.kavilgroup.gelectrical.json

### DIFF
--- a/com.kavilgroup.gelectrical.json
+++ b/com.kavilgroup.gelectrical.json
@@ -421,8 +421,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/manuvarkey/GElectrical.git",
-                    "tag": "v1.1",
-                    "commit": "72929352b5a2b6ddf8b3baae40f4dba2f876f810"
+                    "tag": "v1.1.1",
+                    "commit": "cf6e3ae5e7daa7fba280a26e061e896731143e14"
                 }
             ]
         }


### PR DESCRIPTION
Update metainfo to match new guidelines